### PR TITLE
Fix filter account operations from blockheight is broken

### DIFF
--- a/core/src/database/query/filters_impl.cpp
+++ b/core/src/database/query/filters_impl.cpp
@@ -151,31 +151,31 @@ namespace ledger {
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightEq(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", "=", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", "=", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightNeq(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", "<>", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", "<>", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightLt(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", "<", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", "<", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightLte(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", "<=", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", "<=", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightGt(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", ">", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", ">", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightGte(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", ">=", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", ">=", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightIsNull() {
-            return std::make_shared<PlainTextConditionQueryFilter>("o.block_height IS NULL");
+            return std::make_shared<PlainTextConditionQueryFilter>("b.height IS NULL");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::operationTypeEq(api::OperationType type) {


### PR DESCRIPTION
Quick fix for column db naming that is not correct anymore.
Blockheight is broken here when we are trying to get operation from a given block height : 

`Dynamic exception type: soci::postgresql_soci_error
std::exception::what: Cannot prepare statement. ERROR:  column o.block_height does not exist
LINE 1: ... o.block_uid = b.uid WHERE o.account_uid = $1 AND o.block_he...`